### PR TITLE
chore: lifecycle demo from v0.3.0 to v0.5.0

### DIFF
--- a/clusters/demo/infrastructure.yaml
+++ b/clusters/demo/infrastructure.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 1m
   url: https://github.com/VincentVonBueren/flux-demo.git
   ref:
-    tag: v0.3.0
+    tag: v0.5.0
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization


### PR DESCRIPTION
- Lifecycle this demo cluster